### PR TITLE
Document mindmap style parsing, wrapping, and Creole pitfalls

### DIFF
--- a/mindmap/SKILL.md
+++ b/mindmap/SKILL.md
@@ -28,7 +28,13 @@ metadata:
   - `*[#Orange] Root`
   - `**[#lightgreen] Child`
 - For reusable themes, define `<style>` and apply stereotypes like `<<green>>`
+- **Put exactly one style property per line.** `node { Padding 8 Margin 6 }` silently
+  mis-parses and renders every box narrower than its text, clipping a character off each
+  edge — see [styling-pitfalls.md](examples/styling-pitfalls.md)
+- To wrap long node text instead of stretching the diagram, set `MaximumWidth` on `node`
 - Rich text/Creole and icon syntax are supported inside node text (see examples)
+- Creole is active inside node text: a wrapped line starting with `=`, `-`, `*`, or `#`
+  turns into a heading or list item. Indent the continuation one space to keep it literal
 
 ## Node Syntax Cheat Sheet
 
@@ -60,6 +66,29 @@ metadata:
 | Reusable class style | `<style> ... .green { ... } </style>` + `<<green>>` | Consistent visual themes |
 | Depth-based style | `:depth(1) { ... }` | Global formatting by hierarchy depth |
 | Node/arrow global style | `node { ... }` / `arrow { ... }` | Unified typography and connectors |
+| Text wrapping | `node { MaximumWidth 320 }` | Long labels that would otherwise stretch the map |
+
+> ⚠️ **One property per line.** The style parser reads a single property per line. Collapsing
+> them (`node { Padding 8 Margin 6 RoundCorner 10 }`) does not error — it mis-parses the values
+> and clips the text of *every* node. See [styling-pitfalls.md](examples/styling-pitfalls.md).
+
+```plantuml
+@startmindmap
+<style>
+mindmapDiagram {
+  node {
+    Padding 8
+    Margin 6
+    RoundCorner 10
+    MaximumWidth 320
+  }
+}
+</style>
+* Styling
+** One property per line
+** MaximumWidth wraps long labels instead of stretching the map
+@endmindmap
+```
 
 ## Recommended Color Palettes
 
@@ -125,6 +154,7 @@ Pick a palette that matches the map's purpose. Use inline `[#hex]` for quick col
 | Direction Control | Vertical or RTL reading direction | [direction-control.md](examples/direction-control.md) |
 | Rich Text Content | Detailed notes with icons and formatting | [rich-text-content.md](examples/rich-text-content.md) |
 | Project Planning | Work breakdown and action map | [project-planning.md](examples/project-planning.md) |
+| Styling Pitfalls | Silent clipping, wrapping, Creole and Unicode traps | [styling-pitfalls.md](examples/styling-pitfalls.md) |
 
 ## Quick Example
 
@@ -156,3 +186,8 @@ right to left direction
 | Multi-line text breaks parser | Use `: ... ;` block syntax, ensure trailing `;` exists |
 | Colors not applied | Verify hex format (`#RRGGBB`) or stereotype class names |
 | Layout direction unexpected | Add explicit `top to bottom direction` or `right to left direction` |
+| **Text clipped on every box** | Two or more style properties share a line — put one per line |
+| One long node stretches the whole map | Set `node { MaximumWidth 320 }` to wrap instead |
+| A wrapped line renders bold/large | It starts with `=` (Creole heading) — indent it one space |
+| A wrapped line gains a bullet or number | It starts with `-`, `*`, or `#` — indent it one space |
+| Accents vanish (`θ̂` loses its hat) | Combining diacritics do not render; use `θ^`, or a precomposed character like `ŷ` |

--- a/mindmap/examples/styling-pitfalls.md
+++ b/mindmap/examples/styling-pitfalls.md
@@ -1,0 +1,109 @@
+# Styling and Text Pitfalls
+
+Four failure modes that render **without any error message**, so they are easy to ship
+unnoticed. All four were reproduced against PlantUML 1.2025.2.
+
+## 1. Text clipped on every box
+
+The style parser reads **one property per line**. Collapsing several onto a single line
+does not raise an error — it mis-parses the values and computes box widths *narrower than
+the text*, so every node in the diagram loses a character off each edge (`1.5 Data`
+renders as `.5 Data`).
+
+```plantuml
+' WRONG — silently clips the text of every node
+@startmindmap
+<style>
+mindmapDiagram {
+  node { Padding 8 Margin 6 RoundCorner 10 }
+}
+</style>
+* Root Node Here
+** All unknowns = random variables
+@endmindmap
+```
+
+```plantuml
+' CORRECT — one property per line
+@startmindmap
+<style>
+mindmapDiagram {
+  node {
+    Padding 8
+    Margin 6
+    RoundCorner 10
+  }
+}
+</style>
+* Root Node Here
+** All unknowns = random variables
+@endmindmap
+```
+
+Isolating it: `Padding 8` alone renders correctly, `Margin 6` alone renders correctly,
+`Padding 8 Margin 6` on one line clips. The trigger is the second property on the line,
+not any particular property.
+
+## 2. One long label stretches the whole map
+
+Mind map nodes do not wrap by default, so a single long label widens the entire diagram.
+Set `MaximumWidth` on `node` to wrap instead.
+
+```plantuml
+@startmindmap
+<style>
+mindmapDiagram {
+  node {
+    MaximumWidth 260
+  }
+}
+</style>
+* Root
+** This is a deliberately long node label that wraps onto several lines instead of running off
+@endmindmap
+```
+
+## 3. Creole markup fires on wrapped lines
+
+Creole is active inside node text, and it is evaluated per line. A continuation line after
+`\n` that begins with a markup character is transformed:
+
+| Line starts with | Renders as |
+|---|---|
+| `=` | Heading — large and bold |
+| `-` | List item, and the `-` becomes `–` |
+| `*` | Bullet list item |
+| `#` | Numbered list item |
+| `\|` | Safe — passes through literally |
+
+This bites hardest on multi-line equations, where a continuation naturally starts with `=`:
+
+```plantuml
+@startmindmap
+* Root
+' WRONG — second line renders as a bold heading
+** L(θ) = argmin\n= (1/N) Σ ℓ(y, f(x))
+' CORRECT — one leading space keeps it literal
+** L(θ) = argmin\n     = (1/N) Σ ℓ(y, f(x))
+@endmindmap
+```
+
+Indenting the continuation by a single space defuses every case.
+
+## 4. Combining diacritics do not render
+
+Characters built from a base letter plus a combining mark (U+0300–U+036F) lose the mark.
+`θ̂` (theta + combining circumflex) renders as a bare `θ` in the default font, and as a
+misaligned `θˆ` in `Monospaced`. Setting `FontName Monospaced` additionally drops Unicode
+subscripts such as `ₙ`.
+
+Use an ASCII suffix (`θ^`, `x~`) or a **precomposed** character where one exists
+(`ŷ` U+0177, `μ`, `σ`). Plain Unicode maths symbols are fine: `≜ ∈ ℝ Σ √ ≠ ≫ ⇒ → ᵀ ᴰ ₙ ₁ ²`.
+
+## Pattern Notes
+
+1. One style property per line — the single highest-value rule in this file.
+2. Add `MaximumWidth` whenever nodes carry sentences rather than short phrases.
+3. Indent any continuation line that starts with `=`, `-`, `*`, or `#`.
+4. Prefer precomposed or ASCII-suffixed characters over combining diacritics.
+5. None of these produce a warning, so verify by rendering, not by reading the source.


### PR DESCRIPTION
Four failure modes that render without any error message, all reproduced against PlantUML 1.2025.2:

- The style parser reads one property per line. Collapsing several onto one line (node { Padding 8 Margin 6 RoundCorner 10 }) mis-parses the values and computes box widths narrower than the text, clipping a character off every node in the diagram. Isolated: either property alone renders correctly.
- Nodes do not wrap, so one long label stretches the whole map. Documents MaximumWidth on node as the fix.
- Creole is evaluated per line inside node text, so a continuation line after \n starting with =, -, * or # becomes a heading or list item. Verified that | is safe and that one leading space defuses every case.
- Combining diacritics do not render, so a hat is silently dropped. Recommends an ASCII suffix or a precomposed character.

Adds examples/styling-pitfalls.md with self-demonstrating WRONG/CORRECT pairs, links it from Critical Rules, Styling Options, and the patterns table, and extends the Common Pitfalls table with a row per symptom.


Claude-Session: https://claude.ai/code/session_01RibpG1pmCUVEU27FtNTz9z